### PR TITLE
Add new elements to keywords

### DIFF
--- a/keywords
+++ b/keywords
@@ -9,6 +9,7 @@ enum element {
   el_namespaces,
   el_namespace,
   el_page,
+  el_redirect,
   el_title,
   el_id,
   el_restrictions,
@@ -33,6 +34,7 @@ case,         el_case
 namespaces,   el_namespaces
 namespace,    el_namespace
 page,         el_page
+redirect,     el_redirect
 title,        el_title
 id,           el_id
 restrictions, el_restrictions

--- a/keywords
+++ b/keywords
@@ -9,9 +9,11 @@ enum element {
   el_namespaces,
   el_namespace,
   el_page,
-  el_redirect,
   el_title,
+  el_ns,
   el_id,
+  el_redirect,
+  el_sha1,
   el_restrictions,
   el_revision,
   el_timestamp,
@@ -34,9 +36,11 @@ case,         el_case
 namespaces,   el_namespaces
 namespace,    el_namespace
 page,         el_page
-redirect,     el_redirect
 title,        el_title
+ns,           el_ns
 id,           el_id
+redirect,     el_redirect
+sha1,         el_sha1
 restrictions, el_restrictions
 revision,     el_revision
 timestamp,    el_timestamp

--- a/mediawiki.c
+++ b/mediawiki.c
@@ -41,9 +41,11 @@ enum element {
   el_namespaces,
   el_namespace,
   el_page,
-  el_redirect,
   el_title,
+  el_ns,
   el_id,
+  el_redirect,
+  el_sha1,
   el_restrictions,
   el_revision,
   el_timestamp,
@@ -54,15 +56,15 @@ enum element {
   el_comment,
   el_text,
 };
-#line 26 "keywords"
+#line 28 "keywords"
 struct eltmap { char *name; enum element t; };
 
-#define TOTAL_KEYWORDS 21
+#define TOTAL_KEYWORDS 23
 #define MIN_WORD_LENGTH 2
 #define MAX_WORD_LENGTH 12
-#define MIN_HASH_VALUE 2
-#define MAX_HASH_VALUE 34
-/* maximum key range = 33, duplicates = 0 */
+#define MIN_HASH_VALUE 4
+#define MAX_HASH_VALUE 39
+/* maximum key range = 36, duplicates = 0 */
 
 #ifdef __GNUC__
 __inline
@@ -78,32 +80,32 @@ hash (str, len)
 {
   static const unsigned char asso_values[] =
     {
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35,  3,  5,
-       0,  0, 35, 25, 35,  0, 35, 35, 35,  5,
-      10, 15, 20, 35,  0,  5,  0, 15, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
-      35, 35, 35, 35, 35, 35
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 30,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40,  3,  5,
+      15,  0, 40, 25, 40, 15, 40, 40, 40,  5,
+      15, 15, 10, 40,  0,  5,  0, 10, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
+      40, 40, 40, 40, 40, 40
     };
   return len + asso_values[(unsigned char)str[len - 1]] + asso_values[(unsigned char)str[0]];
 }
@@ -121,56 +123,61 @@ lu_elt (str, len)
 {
   static const struct eltmap wordlist[] =
     {
-      {""}, {""},
-#line 39 "keywords"
-      {"id",           el_id},
-      {""},
-#line 48 "keywords"
+      {""}, {""}, {""}, {""},
+#line 52 "keywords"
       {"text",         el_text},
-#line 38 "keywords"
+#line 39 "keywords"
       {"title",        el_title},
       {""},
-#line 31 "keywords"
-      {"base",         el_base},
-#line 37 "keywords"
-      {"redirect",     el_redirect},
 #line 33 "keywords"
+      {"base",         el_base},
+#line 42 "keywords"
+      {"redirect",     el_redirect},
+#line 35 "keywords"
       {"case",         el_case},
-#line 46 "keywords"
+#line 50 "keywords"
       {"minor",        el_minor},
       {""},
-#line 47 "keywords"
+#line 51 "keywords"
       {"comment",      el_comment},
-#line 30 "keywords"
+#line 32 "keywords"
       {"sitename",     el_sitename},
-#line 28 "keywords"
-      {"mediawiki",    el_mediawiki},
+#line 38 "keywords"
+      {"page",         el_page},
       {""},
-#line 43 "keywords"
+#line 47 "keywords"
       {"contributor",  el_contributor},
-#line 40 "keywords"
+#line 44 "keywords"
       {"restrictions", el_restrictions},
-#line 41 "keywords"
+#line 48 "keywords"
+      {"username",     el_username},
+#line 46 "keywords"
+      {"timestamp",    el_timestamp},
+      {""}, {""},
+#line 40 "keywords"
+      {"ns",           el_ns},
+#line 45 "keywords"
       {"revision",     el_revision},
-#line 35 "keywords"
+#line 37 "keywords"
       {"namespace",    el_namespace},
       {""}, {""},
-#line 45 "keywords"
+#line 49 "keywords"
       {"ip",           el_ip},
-#line 44 "keywords"
-      {"username",     el_username},
-#line 36 "keywords"
-      {"page",         el_page},
-#line 34 "keywords"
-      {"namespaces",   el_namespaces},
-      {""}, {""},
-#line 29 "keywords"
+#line 31 "keywords"
       {"siteinfo",     el_siteinfo},
-#line 42 "keywords"
-      {"timestamp",    el_timestamp},
+#line 30 "keywords"
+      {"mediawiki",    el_mediawiki},
+#line 36 "keywords"
+      {"namespaces",   el_namespaces},
+      {""},
+#line 41 "keywords"
+      {"id",           el_id},
+      {""},
+#line 34 "keywords"
+      {"generator",    el_generator},
       {""}, {""}, {""}, {""},
-#line 32 "keywords"
-      {"generator",    el_generator}
+#line 43 "keywords"
+      {"sha1",         el_sha1}
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)

--- a/mediawiki.c
+++ b/mediawiki.c
@@ -1,4 +1,4 @@
-/* C code produced by gperf version 3.0.1 */
+/* C code produced by gperf version 3.0.3 */
 /* Command-line: gperf -gptoC -Nlu_elt keywords  */
 /* Computed positions: -k'1,$' */
 
@@ -41,6 +41,7 @@ enum element {
   el_namespaces,
   el_namespace,
   el_page,
+  el_redirect,
   el_title,
   el_id,
   el_restrictions,
@@ -53,15 +54,15 @@ enum element {
   el_comment,
   el_text,
 };
-#line 25 "keywords"
+#line 26 "keywords"
 struct eltmap { char *name; enum element t; };
 
-#define TOTAL_KEYWORDS 20
+#define TOTAL_KEYWORDS 21
 #define MIN_WORD_LENGTH 2
 #define MAX_WORD_LENGTH 12
-#define MIN_HASH_VALUE 4
-#define MAX_HASH_VALUE 42
-/* maximum key range = 39, duplicates = 0 */
+#define MIN_HASH_VALUE 2
+#define MAX_HASH_VALUE 34
+/* maximum key range = 33, duplicates = 0 */
 
 #ifdef __GNUC__
 __inline
@@ -77,38 +78,41 @@ hash (str, len)
 {
   static const unsigned char asso_values[] =
     {
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43,  3, 15,
-       5,  0, 43,  0, 43, 20, 43, 43, 43,  5,
-       5, 15, 20, 43,  0,  0,  0, 10, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43, 43, 43, 43, 43,
-      43, 43, 43, 43, 43, 43
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35,  3,  5,
+       0,  0, 35, 25, 35,  0, 35, 35, 35,  5,
+      10, 15, 20, 35,  0,  5,  0, 15, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35, 35, 35, 35, 35,
+      35, 35, 35, 35, 35, 35
     };
   return len + asso_values[(unsigned char)str[len - 1]] + asso_values[(unsigned char)str[0]];
 }
 
 #ifdef __GNUC__
 __inline
+#ifdef __GNUC_STDC_INLINE__
+__attribute__ ((__gnu_inline__))
+#endif
 #endif
 const struct eltmap *
 lu_elt (str, len)
@@ -117,55 +121,56 @@ lu_elt (str, len)
 {
   static const struct eltmap wordlist[] =
     {
-      {""}, {""}, {""}, {""},
-#line 46 "keywords"
-      {"text",         el_text},
-#line 36 "keywords"
-      {"title",        el_title},
-      {""},
-#line 30 "keywords"
-      {"base",         el_base},
-#line 29 "keywords"
-      {"sitename",     el_sitename},
-#line 31 "keywords"
-      {"generator",    el_generator},
-#line 44 "keywords"
-      {"minor",        el_minor},
-      {""},
-#line 38 "keywords"
-      {"restrictions", el_restrictions},
+      {""}, {""},
 #line 39 "keywords"
-      {"revision",     el_revision},
-#line 34 "keywords"
-      {"namespace",    el_namespace},
-#line 33 "keywords"
-      {"namespaces",   el_namespaces},
-      {""}, {""},
-#line 42 "keywords"
-      {"username",     el_username},
-#line 32 "keywords"
-      {"case",         el_case},
-      {""}, {""},
-#line 45 "keywords"
-      {"comment",      el_comment},
-#line 28 "keywords"
-      {"siteinfo",     el_siteinfo},
-#line 35 "keywords"
-      {"page",         el_page},
-      {""},
-#line 41 "keywords"
-      {"contributor",  el_contributor},
-#line 37 "keywords"
       {"id",           el_id},
       {""},
+#line 48 "keywords"
+      {"text",         el_text},
+#line 38 "keywords"
+      {"title",        el_title},
+      {""},
+#line 31 "keywords"
+      {"base",         el_base},
+#line 37 "keywords"
+      {"redirect",     el_redirect},
+#line 33 "keywords"
+      {"case",         el_case},
+#line 46 "keywords"
+      {"minor",        el_minor},
+      {""},
+#line 47 "keywords"
+      {"comment",      el_comment},
+#line 30 "keywords"
+      {"sitename",     el_sitename},
+#line 28 "keywords"
+      {"mediawiki",    el_mediawiki},
+      {""},
+#line 43 "keywords"
+      {"contributor",  el_contributor},
 #line 40 "keywords"
+      {"restrictions", el_restrictions},
+#line 41 "keywords"
+      {"revision",     el_revision},
+#line 35 "keywords"
+      {"namespace",    el_namespace},
+      {""}, {""},
+#line 45 "keywords"
+      {"ip",           el_ip},
+#line 44 "keywords"
+      {"username",     el_username},
+#line 36 "keywords"
+      {"page",         el_page},
+#line 34 "keywords"
+      {"namespaces",   el_namespaces},
+      {""}, {""},
+#line 29 "keywords"
+      {"siteinfo",     el_siteinfo},
+#line 42 "keywords"
       {"timestamp",    el_timestamp},
       {""}, {""}, {""}, {""},
-#line 27 "keywords"
-      {"mediawiki",    el_mediawiki},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 43 "keywords"
-      {"ip",           el_ip}
+#line 32 "keywords"
+      {"generator",    el_generator}
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)


### PR DESCRIPTION
I added the `redirect`, `ns` and `sha1` to keywords and regenerated mediawiki.c with the gperf. This effectively noops any of these elements but will not raise an unknown element error. This appears to fix the latest enwiki-pages-articles dumps.
